### PR TITLE
add tmp dir for web.pid to be placed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     command: bin/bundle exec unicorn -c config/unicorn.rb -E production
     volumes:
       - ./data:/diaspora/public/
+      - ./tmp:/diaspora/tmp/
       - ./config/diaspora.toml:/diaspora/config/diaspora.toml
       - ./config/database.yml:/diaspora/config/database.yml
     depends_on:


### PR DESCRIPTION
Fixes #64.

TODO: Add tmp dir creation to docker-compose production setup.